### PR TITLE
Resolves #61

### DIFF
--- a/sdk/kvstore-macros/src/model/impl_block.rs
+++ b/sdk/kvstore-macros/src/model/impl_block.rs
@@ -36,15 +36,18 @@ pub fn fn_get(key_attributes: &KeyAttributes) -> TokenStream {
     }
 }
 
-pub fn fn_get_or_default(key_attributes: &KeyAttributes) -> TokenStream {
+pub fn fn_get_or(key_attributes: &KeyAttributes) -> TokenStream {
     let parameters = key_attributes.as_function_parameters();
     let key_names = key_attributes.iter().map(|key| &key.name);
 
     quote! {
-        pub fn get_or_default(#parameters) -> std::result::Result<Self, radius_sdk::kvstore::KvStoreError> {
+        pub fn get_or<F>(#parameters function: F) -> std::result::Result<Self, radius_sdk::kvstore::KvStoreError>
+        where
+            F: FnOnce() -> Self,
+        {
             let key = &(Self::ID, #(#key_names,)*);
 
-            radius_sdk::kvstore::kvstore()?.get_or_default(key)
+            radius_sdk::kvstore::kvstore()?.get_or(key, function)
         }
     }
 }
@@ -62,15 +65,18 @@ pub fn fn_get_mut(key_attributes: &KeyAttributes) -> TokenStream {
     }
 }
 
-pub fn fn_get_mut_or_default(key_attributes: &KeyAttributes) -> TokenStream {
+pub fn fn_get_mut_or(key_attributes: &KeyAttributes) -> TokenStream {
     let parameters = key_attributes.as_function_parameters();
     let key_names = key_attributes.iter().map(|key| &key.name);
 
     quote! {
-        pub fn get_mut_or_default(#parameters) -> std::result::Result<radius_sdk::kvstore::Lock<'static, Self>, radius_sdk::kvstore::KvStoreError> {
+        pub fn get_mut_or<F>(#parameters function: F) -> std::result::Result<radius_sdk::kvstore::Lock<'static, Self>, radius_sdk::kvstore::KvStoreError>
+        where
+            F: FnOnce() -> Self,
+        {
             let key = &(Self::ID, #(#key_names,)*);
 
-            radius_sdk::kvstore::kvstore()?.get_mut_or_default(key)
+            radius_sdk::kvstore::kvstore()?.get_mut_or(key, function)
         }
     }
 }

--- a/sdk/kvstore-macros/src/model/mod.rs
+++ b/sdk/kvstore-macros/src/model/mod.rs
@@ -14,9 +14,9 @@ pub fn expand_derive_model(input: &mut DeriveInput) -> Result<TokenStream> {
     let id = const_id(&ident);
     let put = fn_put(&key_attributes);
     let get = fn_get(&key_attributes);
-    let get_or_default = fn_get_or_default(&key_attributes);
+    let get_or = fn_get_or(&key_attributes);
     let get_mut = fn_get_mut(&key_attributes);
-    let get_mut_or_default = fn_get_mut_or_default(&key_attributes);
+    let get_mut_or = fn_get_mut_or(&key_attributes);
     let apply = fn_apply(&key_attributes);
     let delete = fn_delete(&key_attributes);
 
@@ -25,9 +25,9 @@ pub fn expand_derive_model(input: &mut DeriveInput) -> Result<TokenStream> {
             #id
             #put
             #get
-            #get_or_default
+            #get_or
             #get_mut
-            #get_mut_or_default
+            #get_mut_or
             #apply
             #delete
         }


### PR DESCRIPTION
- Added `get_or()` and `get_mut_or()` as default implementations for `Model` derive macro.
- Removed `get_or_default()` and `get_mut_or_default()` implementations from `Model` derive macro because it forces the value type to derive `Default`.