### PR TITLE
Resolve #68

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4021,6 +4021,7 @@ dependencies = [
  "chrono",
  "futures",
  "rand",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/validation-eigenlayer/Cargo.toml
+++ b/crates/validation-eigenlayer/Cargo.toml
@@ -3,6 +3,9 @@ name = "validation-eigenlayer"
 version = "0.1.0"
 edition = "2021"
 
+[dev-dependencies]
+tokio = { workspace = true, features = ["full"] }
+
 [dependencies]
 alloy = { workspace = true, features = ["full", "reqwest", "signer-local"] }
 chrono = "0.4"

--- a/crates/validation-symbiotic/Cargo.toml
+++ b/crates/validation-symbiotic/Cargo.toml
@@ -3,11 +3,11 @@ name = "validation-symbiotic"
 version = "0.1.0"
 edition = "2021"
 
+[dev-dependencies]
+tokio = { workspace = true, features = ["full"] }
+
 [dependencies]
 alloy = { workspace = true, features = ["full", "reqwest", "signer-local"] }
 chrono = "0.4"
 futures = { workspace = true }
 rand = { workspace = true }
-
-[dev-dependencies]
-tokio = { workspace = true, features = ["full"] }


### PR DESCRIPTION
# ChangeLog
- Modify the `register_block_commitment()` for both `sdk/validation-eigenlayer` and `sdk/validation-symbiotic` to have the same API and return `PublisherError::BlockCommitmentLength(usize)` if the length of the block commitment as a slice does not match the length specified by the contract.