### PR TITLE
Changes made for https://github.com/radiusxyz/sequencer/issues/53

### DIFF
--- a/crates/liveness-radius/src/publisher.rs
+++ b/crates/liveness-radius/src/publisher.rs
@@ -3,6 +3,7 @@ use std::str::FromStr;
 use alloy::{
     contract,
     network::{Ethereum, EthereumWallet},
+    primitives::{Address, FixedBytes, Uint},
     providers::{
         fillers::{ChainIdFiller, FillProvider, GasFiller, JoinFill, NonceFiller, WalletFiller},
         Identity, PendingTransactionBuilder, Provider, ProviderBuilder, RootProvider,

--- a/crates/liveness-radius/src/subscriber.rs
+++ b/crates/liveness-radius/src/subscriber.rs
@@ -81,20 +81,20 @@ impl Subscriber {
     ///         Events::Block(block) => {
     ///             // Handle Ethereum block creation event.
     ///         }
-    ///         Events::LivenessEvents((event, log)) => match event {
-    ///             LivenessEvents::InitializeCluster => {
+    ///         Events::LivenessEvents(liveness_event, log) => match liveness_event {
+    ///             LivenessEvents::InitializeCluster(event) => {
     ///                 // Handle `InitializeCluster` event.
     ///             }
-    ///             LivenessEvents::RegisterSequencer => {
+    ///             LivenessEvents::RegisterSequencer(event) => {
     ///                 // Handle `RegisterSequencer` event.
     ///             }
-    ///             LivenessEvents::DeregisterSequencer => {
+    ///             LivenessEvents::DeregisterSequencer(event) => {
     ///                 // Handle `DeregisterSequencer` event.
     ///             }
-    ///             LivenessEvents::AddRollup => {
+    ///             LivenessEvents::AddRollup(event) => {
     ///                 // Handle `AddRollup` event.
     ///             }
-    ///             LivenessEvents::RegisterRollupExecutor => {
+    ///             LivenessEvents::RegisterRollupExecutor(event) => {
     ///                 // Handle `RegisterRollupExecutor` event.
     ///             }
     ///         },

--- a/crates/liveness-radius/src/subscriber.rs
+++ b/crates/liveness-radius/src/subscriber.rs
@@ -81,7 +81,7 @@ impl Subscriber {
     ///         Events::Block(block) => {
     ///             // Handle Ethereum block creation event.
     ///         }
-    ///         Events::LivenessEvents(contract_events) => match contract_events {
+    ///         Events::LivenessEvents((event, log)) => match event {
     ///             LivenessEvents::InitializeCluster => {
     ///                 // Handle `InitializeCluster` event.
     ///             }

--- a/crates/liveness-radius/src/types.rs
+++ b/crates/liveness-radius/src/types.rs
@@ -1,7 +1,4 @@
-pub use alloy::{
-    primitives::*,
-    rpc::types::{Block, Log},
-};
+pub use alloy::{primitives, rpc};
 
 alloy::sol!(
     #[allow(missing_docs)]
@@ -11,12 +8,6 @@ alloy::sol!(
 );
 
 pub enum Events {
-    Block(Block),
-    LivenessEvents(Liveness::LivenessEvents),
-}
-
-impl From<Liveness::LivenessEvents> for Events {
-    fn from(value: Liveness::LivenessEvents) -> Self {
-        Self::LivenessEvents(value)
-    }
+    Block(rpc::types::Block),
+    LivenessEvents(Liveness::LivenessEvents, rpc::types::Log),
 }


### PR DESCRIPTION
# Changelog
- Change `Log` type from `alloy::primitives::Log` to `alloy::rpc::types::Log`.
- `LivenessEvents` parameter changed from `LivenessEvents` to (`LivenessEvents`, `alloy::rpc::types::Log`) tuple.
- Update documentations accordingly.