### PR TITLE
Use identifier in `write!` macro

### DIFF
--- a/crates/context/src/ebr.rs
+++ b/crates/context/src/ebr.rs
@@ -176,7 +176,7 @@ impl std::fmt::Debug for ContextError {
 
 impl std::fmt::Display for ContextError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/crates/json-rpc/json-rpc-client/src/lib.rs
+++ b/crates/json-rpc/json-rpc-client/src/lib.rs
@@ -507,7 +507,7 @@ unsafe impl Send for RpcClientError {}
 
 impl std::fmt::Display for RpcClientError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/crates/json-rpc/json-rpc-server/src/lib.rs
+++ b/crates/json-rpc/json-rpc-server/src/lib.rs
@@ -140,7 +140,7 @@ pub enum RpcServerError {
 
 impl std::fmt::Display for RpcServerError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/crates/kvstore/kvstore/src/data_type/bytes.rs
+++ b/crates/kvstore/kvstore/src/data_type/bytes.rs
@@ -34,7 +34,7 @@ pub enum DataTypeError {
 
 impl std::fmt::Display for DataTypeError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/crates/kvstore/kvstore/src/data_type/json.rs
+++ b/crates/kvstore/kvstore/src/data_type/json.rs
@@ -34,7 +34,7 @@ pub enum DataTypeError {
 
 impl std::fmt::Display for DataTypeError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/crates/kvstore/kvstore/src/in_memory.rs
+++ b/crates/kvstore/kvstore/src/in_memory.rs
@@ -238,7 +238,7 @@ pub enum CachedKvStoreError {
 
 impl std::fmt::Display for CachedKvStoreError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/crates/kvstore/kvstore/src/on_disk.rs
+++ b/crates/kvstore/kvstore/src/on_disk.rs
@@ -448,7 +448,7 @@ pub enum KvStoreError {
 
 impl std::fmt::Display for KvStoreError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}",)
     }
 }
 

--- a/crates/liveness/liveness-radius/src/publisher.rs
+++ b/crates/liveness/liveness-radius/src/publisher.rs
@@ -679,7 +679,7 @@ pub enum TransactionError {
 
 impl std::fmt::Display for TransactionError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 
@@ -705,7 +705,7 @@ pub enum PublisherError {
 
 impl std::fmt::Display for PublisherError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/crates/liveness/liveness-radius/src/subscriber.rs
+++ b/crates/liveness/liveness-radius/src/subscriber.rs
@@ -246,7 +246,7 @@ pub enum SubscriberError {
 
 impl std::fmt::Display for SubscriberError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/crates/signature/src/chain_type/ethereum.rs
+++ b/crates/signature/src/chain_type/ethereum.rs
@@ -202,7 +202,7 @@ pub enum EthereumError {
 
 impl std::fmt::Display for EthereumError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/crates/signature/src/error.rs
+++ b/crates/signature/src/error.rs
@@ -9,7 +9,7 @@ pub enum SignatureError {
 
 impl std::fmt::Display for SignatureError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/crates/validation/validation-eigenlayer/src/publisher.rs
+++ b/crates/validation/validation-eigenlayer/src/publisher.rs
@@ -455,7 +455,7 @@ pub enum TransactionError {
 
 impl std::fmt::Display for TransactionError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 
@@ -480,7 +480,7 @@ pub enum PublisherError {
 
 impl std::fmt::Display for PublisherError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/crates/validation/validation-eigenlayer/src/subscriber.rs
+++ b/crates/validation/validation-eigenlayer/src/subscriber.rs
@@ -110,7 +110,7 @@ pub enum SubscriberError {
 
 impl std::fmt::Display for SubscriberError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/crates/validation/validation-symbiotic/src/publisher.rs
+++ b/crates/validation/validation-symbiotic/src/publisher.rs
@@ -181,7 +181,7 @@ pub enum TransactionError {
 
 impl std::fmt::Display for TransactionError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 
@@ -199,7 +199,7 @@ pub enum PublisherError {
 
 impl std::fmt::Display for PublisherError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/crates/validation/validation-symbiotic/src/subscriber.rs
+++ b/crates/validation/validation-symbiotic/src/subscriber.rs
@@ -117,7 +117,7 @@ pub enum SubscriberError {
 
 impl std::fmt::Display for SubscriberError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 


### PR DESCRIPTION
The formatting machinery does not require passing variables in extra arguments when dealing with identifiers. Therefore, this PR pass them directly which improves readability.